### PR TITLE
Add onload listener for instantiating RecipeRepository and User

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -3,6 +3,10 @@ import apiCalls from './apiCalls';
 import MicroModal from 'micromodal';
 // An example of how you tell webpack to use an image (also need to link to it in the index.html)
 import './images/turing-logo.png'
+import RecipeRepository from './classes/RecipeRepository'
+import recipeData from "./data/recipes"
+import ingredientsData from "./data/ingredients"
+// import Recipe from "./Recipe"
 
 MicroModal.init({
   onShow: modal => console.info(`${modal.id} is shown. Callback ftn to poppulate modal called here?`),
@@ -16,5 +20,12 @@ MicroModal.init({
   awaitCloseAnimation: false,
   debugMode: true 
 });
+
+window.onload = function(){
+  var newRecipeRepo = new RecipeRepository(recipeData, ingredientsData)
+  // var newUser = new User()
+  console.log("newRecipeRepo", newRecipeRepo)
+  // console.log("newUser", newUser)
+}
 
 console.log('Hello world');


### PR DESCRIPTION
This is a simple update to include an `onload` listener that will instantiate a new instance of `RecipeRepository` and `User ` in `scripts.js`. I have commented out part of the function while we wait for the` User` class to be created. There are console logs to test that the variables are accessible in the DOM. 

![image](https://user-images.githubusercontent.com/110144802/197274005-12b9f158-6d01-4696-8ef1-212dc1a69d80.png)
