### PR TITLE
Fix myRecipes view so that page updates when a recipe is unfavorited

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -84,6 +84,11 @@ allRecipesContainer.addEventListener("click", event => {
   } else {
     removeRecipeFromFavorites(event)
   }
+  
+  if (allRecipesButton.classList.contains('selected-view')) {
+    displayAllRecipes();
+  } else { displayMyRecipes() }
+
   let targetObject = recipeRepository.recipeList.find(recipe => recipe.id == event.target.parentNode.id)
   updateModal(targetObject)
 })
@@ -102,7 +107,6 @@ modalSaveRecipeButton.addEventListener("click", event => {
 
 searchBar.addEventListener('keyup', event => {
   let input = event.target.value
-  //utilize toggle to switch search criteria between all recipes and favorites?
   if (searchBar.classList.contains('my-recipes')) {
     let recipes = user.filterByNameOrIngredient(input)
     displaySearchedRecipeTiles(recipes)


### PR DESCRIPTION
#### What's this PR do?
- User can now unfavorite a recipe in the My Recipes section, and the DOM will update to remove the unfavorited tile from view
#### Where should the reviewer start?
- Run `npm start`
- Go to browser
- Click bookmark on several recipes in the All Recipes view
- Proceed to My Recipes view
- "Unfavorite" recipes and notice they disappear from My Recipes view
#### How should this be manually tested?
- See Above
#### Background
- This is a bug fix. Previously, "unfavorited" recipes were not disappearing from the My Recipes view when the user clicked the bookmark