### PR TITLE
Feature/filter my recipes by tag

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -121,11 +121,10 @@ allRecipesButton.addEventListener("click", displayAllRecipes)
 
 filter.addEventListener('input', event => {
   filterClearButton.disabled = false
-  
-  let input = event.target.value
   filterClearButton.classList.remove('disabled')
-
-  if (filter.classList.contains('my-recipes')) {
+  let input = event.target.value
+  
+  if (myRecipesButton.classList.contains('selected-view')) {
     let recipes = user.filterByTag(input)
     displaySearchedRecipeTiles(recipes)
   } else {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -121,7 +121,7 @@ allRecipesButton.addEventListener("click", displayAllRecipes)
 
 filter.addEventListener('input', event => {
   filterClearButton.disabled = false
-  console.log("LOOK HERE", filterClearButton.classList)
+  
   let input = event.target.value
   filterClearButton.classList.remove('disabled')
 


### PR DESCRIPTION
#### What's this PR do?
- allows user to filter My Recipes by tag
- as opposed to filtering All Recipes by tag

#### Where should the reviewer start?
- favorite several recipes
- navigate to My Recipes
- attempt to filter My Recipes by tag
- notice only favorited recipes are visible

#### How should this be manually tested?
- run `npm start`
- navigate to browser in order to test

#### Any background context you want to provide?
- filter event listener handles this with `if/else statement` to check if the "My Recipes" button has the class `selected-view`
- previously attempting to filter My Recipes by tag would re-populate All Recipes

#### Screenshots (if appropriate)
![my-recipes-filter](https://user-images.githubusercontent.com/74210902/197590273-62da868b-a963-4ba6-8a13-8d3ddca11262.png)
