### PR TITLE
Add line of css to header

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -16,7 +16,8 @@ header {
   width: 100%;
   height: 75px;
   background-color: rgb(247, 243, 233, 0.75);
-  box-shadow: 0 3px 10px rgb(0 0 0 / 0.2)
+  box-shadow: 0 3px 10px rgb(0 0 0 / 0.2);
+  z-index: 100;
 }
 
 .nav-bar-container {


### PR DESCRIPTION
### About:
This adds one line of css to ensure the sticky nav bar lies on top of all other elements. 
To test, scroll down on the all recipes view and see that no elements appear on top of the nav bar. 

![styles_css_—_whats-cookin](https://user-images.githubusercontent.com/110144802/197644999-07da6efe-294a-4fd3-a504-013e604bdc95.png)

### Before: 
![image](https://user-images.githubusercontent.com/110144802/197644868-c2c29784-b5a7-4f0d-8946-2b0edfc6939f.png)

### After fix:
![image](https://user-images.githubusercontent.com/110144802/197644890-7561b9f9-8063-43eb-adf5-9642951d9d34.png)



