### PR TITLE
Fix font for smaller screens in css

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -147,7 +147,7 @@ header {
 
 .featured-recipe-title-parent {
   font-family: 'Libre Baskerville', serif;
-  font-size: 1.2vw;
+  font-size: max(1.2vw, 12px);
   width: 40%; 
 }
 
@@ -168,7 +168,7 @@ header {
 
 .special-tag p {
   margin: 2px;
-  font-size: 1.2vw;
+  font-size: max(1.2vw, 10px);
 }
 
 .featured-bookmark-icon {
@@ -214,7 +214,7 @@ header {
 
 .recipe-tile>h1 {
   padding: 5px 5px 0px;
-  font-size: .9vw;
+  font-size: max(1vw, 15px);
 }
 
 .recipe-tile>h1:hover {
@@ -227,7 +227,7 @@ header {
   flex-basis: 20%;
   font-family: 'Work Sans', sans-serif;
   color:#16161679;
-  font-size: 1.2vh;
+  font-size: 12px;
   font-weight: 300;
   padding: 5px;
 }
@@ -499,6 +499,11 @@ select:focus {
 
 @media(max-width:768px) {
 
+  .recipe-details {
+    width: 150%;
+    height: 150%;
+  }
+
   .nav-bar-container {
     width: 100%;
     flex-direction: column;
@@ -530,15 +535,11 @@ select:focus {
   }
 
   .below-header-container {
-    margin-top: 106px;
+    margin-top: 127px;
   }
 
   .filter {
     padding: 2px 10px 2px 18px;
-  }
-
-  .recipe-tile>h1 {
-    font-size: 2vw;
   }
 
   /* MODAL */


### PR DESCRIPTION
This branch fixes the issue where text was getting too small at our breakpoint for smaller screens. The following areas were adjusted in CSS:

- Margin added in our media query to ensure the nav bar doesn't overlap with cards
- Featured recipe translucent background increases in size at breakpoint to accommodate a min font size on smaller screens
- Font size increase in featured section
- Font size increase on tiles

Updated view with adjustments to font size for smaller screens:
![image](https://user-images.githubusercontent.com/110144802/199370382-55dce6c9-dbc6-401b-8c86-0ccbcf93260c.png)
