### PR TITLE
Refactor search bar and search by tag 

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -75,6 +75,8 @@ function startPage() {
 
 // ---------------------------EVENT LISTENERS---------------------------
 
+filterClearButton.addEventListener('click', clearFilterByTag)
+
 window.addEventListener('load', () => {
   fetchData([usersURL, recipesURL, ingredientsURL])
 })
@@ -107,6 +109,7 @@ modalSaveRecipeButton.addEventListener("click", event => {
 })
 
 searchBar.addEventListener('keyup', event => {
+  clearFilterByTag()
   let input = event.target.value
   if (myRecipesButton.classList.contains('selected-view')) {
     let recipes = user.filterByNameOrIngredient(input)
@@ -122,6 +125,7 @@ myRecipesButton.addEventListener("click", displayMyRecipes)
 allRecipesButton.addEventListener("click", displayAllRecipes)
 
 filter.addEventListener('input', event => {
+  searchBar.value = ''
   filterClearButton.disabled = false
   filterClearButton.classList.remove('disabled')
   let input = event.target.value
@@ -135,7 +139,7 @@ filter.addEventListener('input', event => {
   }
 })
 
-filterClearButton.addEventListener('click', () => {
+function clearFilterByTag() {
   filter.value = 'Filter recipes by type...'
   filterClearButton.disabled = true
   filterClearButton.classList.add('disabled')
@@ -149,7 +153,7 @@ filterClearButton.addEventListener('click', () => {
     displayRecipeTiles(recipeRepository.recipeList)
     updateBookmarks()
   }
-})
+}
 
 featuredRecipeParent.addEventListener("click", event => {
   if (event.target.nodeName === "IMG" && (event.target.src.includes('unsaved'))) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -53,6 +53,10 @@ header {
   font-size: 15px;
 }
 
+.search-bar::-webkit-search-cancel-button{
+  -webkit-appearance: none;
+}
+
 .search-bar:hover {
   border: 1px solid #c84a3186;
   transition-duration: 400ms;

--- a/src/styles.css
+++ b/src/styles.css
@@ -147,7 +147,7 @@ header {
 
 .featured-recipe-title-parent {
   font-family: 'Libre Baskerville', serif;
-  font-size: 1.2vw;
+  font-size: max(1.2vw, 12px);
   width: 40%; 
 }
 
@@ -168,7 +168,7 @@ header {
 
 .special-tag p {
   margin: 2px;
-  font-size: 1.2vw;
+  font-size: max(1.2vw, 10px);
 }
 
 .featured-bookmark-icon {
@@ -214,7 +214,7 @@ header {
 
 .recipe-tile>h1 {
   padding: 5px 5px 0px;
-  font-size: .9vw;
+  font-size: max(1vw, 15px);
 }
 
 .recipe-tile>h1:hover {
@@ -227,7 +227,7 @@ header {
   flex-basis: 20%;
   font-family: 'Work Sans', sans-serif;
   color:#16161679;
-  font-size: 1.2vh;
+  font-size: 12px;
   font-weight: 300;
   padding: 5px;
 }
@@ -499,6 +499,11 @@ select:focus {
 
 @media(max-width:768px) {
 
+  .recipe-details {
+    width: 150%;
+    height: 150%;
+  }
+
   .nav-bar-container {
     width: 100%;
     flex-direction: column;
@@ -530,15 +535,11 @@ select:focus {
   }
 
   .below-header-container {
-    margin-top: 106px;
+    margin-top: 127px;
   }
 
   .filter {
     padding: 2px 10px 2px 18px;
-  }
-
-  .recipe-tile>h1 {
-    font-size: 2vw;
   }
 
   /* MODAL */


### PR DESCRIPTION
This update makes changes in `scripts.js` so that when either the search by tag or search bar is being used the unused field is reset. This is to avoid confusion for the end user as to what they are filtering or searching by.

- Refactored the anonymous callback function on our event listener for the search bar into a separate function that I could reuse for this purpose.
- Added a line of code to reset the value of the search bar input to an empty string when the filter by tag is being used.
- Removed the default "x" from our search bar in css. 

![filter](https://user-images.githubusercontent.com/110144802/199379876-62c76aea-019e-4d9f-b619-61c21d0defe9.gif)
