### PR TITLE
REFACTOR: Scripts.js 11/01

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -93,7 +93,6 @@ window.addEventListener('load', () => {
 
 allRecipesContainer.addEventListener("click", event => {
   if (event.target.nodeName === "SECTION") { return }
-  console.log(event.target)
   let viewingMyRecipes = myRecipesButton.classList.contains('selected-view')
   let targetIsIMG = event.target.nodeName === "IMG"
 
@@ -101,7 +100,7 @@ allRecipesContainer.addEventListener("click", event => {
     addRecipeToFavorites(event)
   } else {
     removeRecipeFromFavorites(event)
-    if (viewingMyRecipes) {
+    if (targetIsIMG && viewingMyRecipes) {
       removeTileFromDisplay(event)
     }
   }
@@ -142,7 +141,7 @@ myRecipesButton.addEventListener("click", displayMyRecipes)
 allRecipesButton.addEventListener("click", displayAllRecipes)
 
 filter.addEventListener('input', event => {
-  enableFilterClearButton()
+  enableFilterClearButton(true)
   let input = event.target.value
   let viewingMyRecipes = myRecipesButton.classList.contains('selected-view')
 
@@ -157,7 +156,7 @@ filter.addEventListener('input', event => {
 
 filterClearButton.addEventListener('click', () => {
   filter.value = 'Filter recipes by type...'
-  disableFilterClearButton()
+  enableFilterClearButton(false)
   let viewingMyRecipes = myRecipesButton.classList.contains('selected-view')
 
   if (viewingMyRecipes) {
@@ -223,7 +222,7 @@ function makeViewButtonActive(button) {
 
 function displayAllRecipes() {
   filter.value = 'Filter recipes by type...'
-  disableFilterClearButton()
+  enableFilterClearButton(false)
   makeViewButtonActive(allRecipesButton)
   displayRecipeTiles(recipeRepository.recipeList)
   updateBookmarks()
@@ -231,7 +230,7 @@ function displayAllRecipes() {
 
 function displayMyRecipes() {
   filter.value = 'Filter recipes by type...'
-  disableFilterClearButton()
+  enableFilterClearButton(false)
   makeViewButtonActive(myRecipesButton)
   displayRecipeTiles(user.favoriteRecipes)
   updateBookmarks()
@@ -242,14 +241,14 @@ function removeTileFromDisplay(event) {
   targetNode.remove()
 }
 
-function enableFilterClearButton() {
-  filterClearButton.disabled = false
-  filterClearButton.classList.remove('disabled')
-}
-
-function disableFilterClearButton() {
-  filterClearButton.disabled = true
-  filterClearButton.classList.add('disabled')
+function enableFilterClearButton(boolean) {
+  if (boolean) {
+    filterClearButton.disabled = false
+    filterClearButton.classList.remove('disabled')
+  } else {
+    filterClearButton.disabled = true
+    filterClearButton.classList.add('disabled')
+  }
 }
 
 function displaySearchedRecipeTiles(searchedRecipes) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -364,10 +364,6 @@ select:focus {
   color:rgb(200, 75, 49)
 }
 
-.close-modal-btn:focus {
-  outline: none;
-}
-
 .modal-content-parent {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## This refactor contains the following changes:

### Refactored Scripts.js according to SRP

- `initPage()`
  - changed function name `startPage()` to `initPage()` per standard naming convention
  - added `initRecipeRepository()` and `initUser()` helper functions and their invocations within `initPage()` per Cass' notes
  - same as above for `displayWelcomeMessage()`

- added `getRandomIndex()` helper function for use in initializing featured recipe and for possible use with future functionality
- added function-scoped boolean variables to several event handlers that make the complex chains of conditional statements more readable (see lines 97, 98, 116, 129, etc.). This was a trick that I saw Tim's friend suggested. Some notes on this:
  - some of the more complex handlers wouldn't allow me to pre-define certain truthy/falsy expressions, since they would evaluate to `undefined` (for example, if the `event.target` has no `.src` because the user clicks on an element without a `.src` attribute) and throw an error at the top of the function. I tried to be consistent with using these boolean variables whenever possible.
  - Although it takes more lines of code to do the same thing, I think it makes the code more readable. That being said, if we decide as a team that this isn't an approach we like, I'm happy to revert it back, and it wouldn't take long.
- added `removeTileFromDisplay()`, which solves the previous issue of having the filter reset when un-saving a recipe in "My Recipes" view. Now, the tile is targeted and removed without refreshing the "My Recipes" view (previously done with `displayCurrentMode()`), allowing us to stay tag-filtered.
- removed `displayCurrentMode()`, since the only functionality it was handling was the functionality explained above.
- added `enableFilterClearButton()` and `disableFilterClearButton()` helper functions to DRY up filtering event handlers.
- added `makeViewButtonActive()` to DRY up DOM functions.

### Styles.css

- removed styling which removed focus outline of close button in modal

### Where to Begin with Review

Please double-check all functionality/user paths have been preserved 