### PR TITLE
Move filterByNameOrIngredient and filterByTag to scripts.js so that r…

### DIFF
--- a/src/classes/RecipeRepository.js
+++ b/src/classes/RecipeRepository.js
@@ -6,29 +6,6 @@ class RecipeRepository {
     this.featuredRecipe = this.getFeaturedRecipe()
   }
 
-  filterByNameOrIngredient(input) {
-    let filteredRecipes = []
-    input = input.toLowerCase()
-    this.recipeList.forEach(recipe => {
-      if (recipe.name.toLowerCase().includes(input)) {
-        filteredRecipes.push(recipe)
-      } else {
-        recipe.ingredients.forEach(ingredient => {
-          if (ingredient.name.toLowerCase().includes(input)) {
-            if (!filteredRecipes.includes(recipe)) {
-              filteredRecipes.push(recipe)
-            }
-          }
-        })
-      }
-    })
-    return filteredRecipes
-  }
-
-  filterByTag(tag) {
-    return this.recipeList.filter(recipe => recipe.tags.includes(tag))
-  }
-
   getFeaturedRecipe() {
     let randomNum = Math.floor(Math.random() * this.recipeList.length)
     return this.recipeList[randomNum]

--- a/src/classes/User.js
+++ b/src/classes/User.js
@@ -21,33 +21,6 @@ class User {
     })
   }
 
-  filterByTag(tag) {
-    return this.favoriteRecipes.filter(recipe => recipe.tags.includes(tag))
-  }
-
-  filterByNameOrIngredient(input) {
-    let filteredRecipes = []
-    input = input.toLowerCase()
-    this.favoriteRecipes.forEach(recipe => {
-      if (recipe.name.toLowerCase().includes(input)) {
-        filteredRecipes.push(recipe)
-      } else {
-        recipe.ingredients.forEach(ingredient => {
-          if (ingredient.name.toLowerCase().includes(input)) {
-            if (!filteredRecipes.includes(recipe)) {
-              filteredRecipes.push(recipe)
-            }
-          }
-        })
-      }
-    })
-    return filteredRecipes
-  }
-
-  filterByTag(tag) {
-    return this.favoriteRecipes.filter(recipe => recipe.tags.includes(tag))
-  }
-
   removeRecipeFromFavorites(id) {
     this.favoriteRecipes.forEach((currentValue, i) => {
       if (id === currentValue.id) {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -126,19 +126,19 @@ modalSaveRecipeButton.addEventListener("click", event => {
 })
 
 const searchBarEvents = ['keyup', 'search']
-searchBarEvents.forEach(index => 
+searchBarEvents.forEach(index =>
   searchBar.addEventListener(index, event => {
-  let input = event.target.value
-  let viewingMyRecipes = myRecipesButton.classList.contains('selected-view')
+    let input = event.target.value
+    let viewingMyRecipes = myRecipesButton.classList.contains('selected-view')
 
-  if (viewingMyRecipes) {
-    let recipes = user.filterByNameOrIngredient(input)
-    displaySearchedRecipeTiles(recipes)
-  } else {
-    let recipes = recipeRepository.filterByNameOrIngredient(input)
-    displaySearchedRecipeTiles(recipes)
-  }
-}))
+    if (viewingMyRecipes) {
+      let recipes = filterByNameOrIngredient(user.favoriteRecipes, input)
+      displaySearchedRecipeTiles(recipes)
+    } else {
+      let recipes = filterByNameOrIngredient(recipeRepository.recipeList, input)
+      displaySearchedRecipeTiles(recipes)
+    }
+  }))
 
 myRecipesButton.addEventListener("click", displayMyRecipes)
 
@@ -152,10 +152,10 @@ filter.addEventListener('input', event => {
   let viewingMyRecipes = myRecipesButton.classList.contains('selected-view')
 
   if (viewingMyRecipes) {
-    let recipes = user.filterByTag(input)
+    let recipes = filterByTag(user.favoriteRecipes, input)
     displaySearchedRecipeTiles(recipes)
   } else {
-    let recipes = recipeRepository.filterByTag(input)
+    let recipes = filterByTag(recipeRepository.recipeList, input)
     displaySearchedRecipeTiles(recipes)
   }
 })
@@ -281,7 +281,8 @@ function convertDecimal(amount) {
 
 function updateModal(targetObject) {
   modalTagParent.innerHTML = ``
-  targetObject.tags.forEach(tag => { modalTagParent.innerHTML += `<button>${tag}</button>`
+  targetObject.tags.forEach(tag => {
+    modalTagParent.innerHTML += `<button>${tag}</button>`
   })
   modalSaveRecipeButton.id = targetObject.id
   if (user.favoriteRecipes.includes(targetObject)) {
@@ -291,7 +292,7 @@ function updateModal(targetObject) {
   }
   modalRecipeTitle.innerHTML = targetObject.name
   modalImage.src = targetObject.image
-  modalImage.alt = targetObject.name 
+  modalImage.alt = targetObject.name
   ingredientsParent.innerHTML = ``
   targetObject.ingredients.forEach(ingredient => {
     ingredientsParent.innerHTML += `<ul>${convertDecimal(ingredient.amount)} ${ingredient.unit} ${ingredient.name}</ul>`
@@ -302,7 +303,6 @@ function updateModal(targetObject) {
     instructionsList.innerHTML += `<li>${item.instruction}</li>`
   })
 
-  
 }
 
 function displayModal(targetObject) {
@@ -357,4 +357,27 @@ function updateBookmarks() {
       bookmark.src = './images/bookmark-tiles-unsaved.png'
     }
   })
+}
+
+function filterByNameOrIngredient(recipes, input) {
+  let filteredRecipes = []
+  input = input.toLowerCase()
+  recipes.forEach(recipe => {
+    if (recipe.name.toLowerCase().includes(input)) {
+      filteredRecipes.push(recipe)
+    } else {
+      recipe.ingredients.forEach(ingredient => {
+        if (ingredient.name.toLowerCase().includes(input)) {
+          if (!filteredRecipes.includes(recipe)) {
+            filteredRecipes.push(recipe)
+          }
+        }
+      })
+    }
+  })
+  return filteredRecipes
+}
+
+function filterByTag(recipes, tag) {
+  return recipes.filter(recipe => recipe.tags.includes(tag))
 }


### PR DESCRIPTION
#### What does this PR do?
The methods `filterByNameOrIngredient` and `filterByTag` have now been moved to `scripts.js` on lines 362 and 381.

#### How should this be manually tested?
After opening the application in the browser, attempt to search for any recipe by name or ingredient. Do the same with the filter by tag option. Proceed to the My Recipes view (after "favoriting" some recipes) and use the same search and filter functions.
#### Any background context you want to provide?
The methods `filterByNameOrIngredient` and `filterByTag` were duplicated in both the `user` class and the `recipeRepository` class. In order to DRY up the code utilizing SRP and in response to instructor feedback, these methods have been moved to the main script and given an extra parameter to make them more dynamic.

#### Screenshots
<img width="601" alt="Screen Shot 2022-11-02 at 7 22 01 PM" src="https://user-images.githubusercontent.com/74210902/199632335-77541ea6-bb4c-4dca-9222-946a6e354c2c.png">
