### PR TITLE
PATCH: MicroModal Console Error

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -203,11 +203,12 @@ featuredRecipeParent.addEventListener("click", event => {
 
 modalCookButton.addEventListener("click", (e) => {
   let recipeID = e.target.getAttribute('recipe-id')
-  console.log(recipeID)
   if (e.target.classList.contains("add-ingredients-button")) {
+    MicroModal.close("modal-1")
     displayMyRecipes()
   } else {
     let recipe = recipeRepository.recipeList.find(recipe => recipe.id == recipeID)
+    MicroModal.close("modal-1")
     cookRecipe(recipe)
   }
 })
@@ -245,7 +246,6 @@ function makeViewButtonActive(button) {
 }
 
 function displayAllRecipes() {
-  MicroModal.close("modal-1")
   filter.value = 'Filter recipes by type...'
   enableFilterClearButton(false)
   makeViewButtonActive(allRecipesButton)
@@ -256,7 +256,6 @@ function displayAllRecipes() {
 }
 
 function displayMyRecipes() {
-  MicroModal.close("modal-1")
   filter.value = 'Filter recipes by type...'
   enableFilterClearButton(false)
   makeViewButtonActive(myRecipesButton)


### PR DESCRIPTION
## This branch is a PATCH for:

Console error thrown when switching between "My Recipes" view and "All Recipes" view. 

### Solution

- `MicroModal.close("modal-1")` was removed from `displayMyRecipes()` and `displayAllRecipes()`
- error was thrown from MicroModal if a modal had not been opened before `MicroModal.close("modal-1")` was invoked inside above functions, because MicroModal was "looking" for a modal ID that hadn't been defined yet.