### PR TITLE
PATCH: saved tiles unsaving when POSTing

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -221,8 +221,7 @@ table.addEventListener('click', (event) => {
     postData(restructuredPantryObj, 'http://localhost:3001/api/v1/users')
       .then(data => {
         usersData = data
-        let userNewPantry = updateUser().pantry
-        user.pantry = user.getAllPantryIngredients(userNewPantry, recipeRepository.allIngredients)
+        user.pantry = user.getAllPantryIngredients(updateUser().pantry, recipeRepository.allIngredients)
         displayPantryView()
       })
   } else { return }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -213,6 +213,21 @@ modalCookButton.addEventListener("click", (e) => {
   }
 })
 
+table.addEventListener('click', (event) => {
+  if (event.target.id === 'table-button-add') {
+    let inputValue = Number(event.target.parentNode.querySelector('select').value)
+    let id = Number(event.target.classList.value)
+    let restructuredPantryObj = structurePost(user.id, id, inputValue)
+    postData(restructuredPantryObj, 'http://localhost:3001/api/v1/users')
+      .then(data => {
+        usersData = data
+        let userNewPantry = updateUser().pantry
+        user.pantry = user.getAllPantryIngredients(userNewPantry, recipeRepository.allIngredients)
+        displayPantryView()
+      })
+  } else { return }
+})
+
 // ---------------------------DOM UPDATING---------------------------
 
 function displayWelcomeMessage() {
@@ -445,22 +460,6 @@ function showFeaturedRecipe() {
   logoImage.style.width = '38%'
   pantryParent.classList.add('hidden')
 }
-
-table.addEventListener('click', (event) => {
-
-  if (event.target.id === 'table-button-add') {
-    let inputValue = Number(event.target.parentNode.querySelector('select').value)
-    let id = Number(event.target.classList.value)
-    let restructuredPantryObj = structurePost(user.id, id, inputValue)
-
-    postData(restructuredPantryObj, 'http://localhost:3001/api/v1/users')
-      .then(data => {
-        usersData = data
-        user = new User(updateUser(), recipeRepository.allIngredients)
-        displayPantryView()
-      })
-  } else { return }
-})
 
 function updateUser() {
   return usersData.find(updatedUser => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -206,7 +206,6 @@ td {
 th {
   position: sticky;
   top: 0;
-  z-index: 9;
   height: 7%;
   font-size: max(1.2vw, 12px);
   font-weight: normal;


### PR DESCRIPTION
## This branch is a patch for the following bug:

Saved recipe tiles were becoming unsaved after adding ingredients to pantry.

### Reason for bug:

Previously, `user` was reinstantiating after re-FETCHing data following a POST. This was causing the user's saved recipes in `user.favoriteRecipes` to be lost.

### Fix:

Now, instead of reinstantiating `user` after re-FETCHing, `user.pantry` is updated, and the initial instance of `user` is kept throughout the user journey.

### Additionally:

The `table` event listener/handler was moved from the DOM updating section, into the Event Handlers section.