### PR TITLE
Refactor event listener on search bar to incorporate function clearFilterByTag

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -145,6 +145,7 @@ modalSaveRecipeButton.addEventListener("click", event => {
 const searchBarEvents = ['keyup', 'search']
 searchBarEvents.forEach(index =>
   searchBar.addEventListener(index, event => {
+    clearFilterByTag()
     let input = event.target.value
     let viewingMyRecipes = myRecipesButton.classList.contains('selected-view')
 
@@ -503,7 +504,7 @@ function fetchUsers() {
   .then(response => response.json())
   .then(data => usersData = data)
   .then(() => {
-    user = new User(updateUser(), recipeRepository.allIngredients)
+    user.pantry = new User(updateUser().pantry, recipeRepository.allIngredients)
     MicroModal.close("modal-1")
     displayPantryView()
     displayMyRecipes()

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -504,7 +504,7 @@ function fetchUsers() {
   .then(response => response.json())
   .then(data => usersData = data)
   .then(() => {
-    user.pantry = new User(updateUser().pantry, recipeRepository.allIngredients)
+    user.pantry = user.getAllPantryIngredients(updateUser().pantry, recipeRepository.allIngredients)
     MicroModal.close("modal-1")
     displayPantryView()
     displayMyRecipes()


### PR DESCRIPTION
#### What's this PR do?
- implements `clearFilterByTag` function within the event listener on the search bar so that the filter bar clears when the user goes to search
- a small patch on line `506` to re-assign user's pantry ingredients, rather than the entire user after get fetch
#### Where should the reviewer start?
Pull down branch and run `npm install` to view in web browser
#### How should this be manually tested?
##### `clearFilterByTag`
Tester should go to `All Recipes` and filter them by any tag. Then proceed to search in the search bar by clicking in text field. Notice the filter bar resets.
- Repeat this same step in My Recipes after favoriting several recipes
##### `fetchUsers`
Tester should start by favoriting several recipes. Then click on any recipes to be cooked (tester may need to add several ingredients in order to get the green `cook recipe` button). Once the recipe has been cooked and the tester is taken back to My Pantry, notice the favorited recipes persist after `get fetch`
#### Screenshots
![image](https://user-images.githubusercontent.com/74210902/200199673-82cd8c31-d914-402b-be42-4cb5785df906.png)
![image](https://user-images.githubusercontent.com/74210902/200199697-ae56682d-dc25-440e-a3b7-31d3a22d32cd.png)
