### PR TITLE
Patch/close modal border overhang

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -145,6 +145,7 @@ modalSaveRecipeButton.addEventListener("click", event => {
 const searchBarEvents = ['keyup', 'search']
 searchBarEvents.forEach(index =>
   searchBar.addEventListener(index, event => {
+    clearFilterByTag()
     let input = event.target.value
     let viewingMyRecipes = myRecipesButton.classList.contains('selected-view')
 
@@ -503,7 +504,7 @@ function fetchUsers() {
   .then(response => response.json())
   .then(data => usersData = data)
   .then(() => {
-    user = new User(updateUser(), recipeRepository.allIngredients)
+    user.pantry = new User(updateUser().pantry, recipeRepository.allIngredients)
     MicroModal.close("modal-1")
     displayPantryView()
     displayMyRecipes()

--- a/src/styles.css
+++ b/src/styles.css
@@ -453,7 +453,8 @@ select:focus {
   background-color: rgba(0, 0, 0, 0);
   border: 0px;
   padding: 7px;
-  padding-right: 20px;
+  margin-top: 5px;
+  margin-right: 20px;
 }
 
 .close-modal-btn:hover {


### PR DESCRIPTION
#### What's this PR do?
The border of the close modal button (in modal view) was overhanging the edge of the modal. This PR is a easy fix to change `margin-top` and `margin-right` on the button.
#### Where should the reviewer start?
Pull down the branch, run `npm start` and navigate to browser
#### How should this be manually tested?
Open a modal and notice the border is 100% within the body of the modal
#### Screenshots
![image](https://user-images.githubusercontent.com/74210902/200201170-4feae128-d37a-4589-bb5f-496cf0f7892b.png)
