### PR TITLE
Bug/remove duplicate ingredients 1

### DIFF
--- a/src/classes/Recipe.js
+++ b/src/classes/Recipe.js
@@ -1,3 +1,4 @@
+const { testIngredients, recipeData, ingredientsData } = require("../data/testData")
 const Ingredient = require("./Ingredient")
 
 class Recipe {
@@ -8,7 +9,7 @@ class Recipe {
     this.instructions = recipe.instructions
     this.name = recipe.name
     this.tags = recipe.tags
- }
+  }
 
   getTotalCost() {
     let total = this.ingredients.reduce((acc, ingredient) => {
@@ -16,12 +17,38 @@ class Recipe {
     }, 0) / 100
     return `$${total.toFixed(2).toString()}`
   }
-  
+
   instantiateIngredients(recipe, ingredientsData) {
-    return recipe.ingredients.map(recipeObject => {
+    let a = recipe.ingredients.map(recipeObject => {
       let targetDatasetObject = ingredientsData.find(datasetObj => recipeObject.id === datasetObj.id)
       return new Ingredient(targetDatasetObject, recipeObject)
     })
+
+    return this.mergeIngredients(a)
+  }
+  mergeIngredients(ingredientsData) {
+    let counter = 0
+    let finalArray = []
+    const listUniqueIds = ingredientsData.reduce((acc, curr) => {
+      if (!acc.includes(curr.id)) {
+        acc.push(curr.id)
+      }
+      return acc
+    }, [])
+    for (var i = 0; i < listUniqueIds.length; i++) {
+      counter = 0
+      const matches = ingredientsData.filter((originalIngredient) => {
+        return listUniqueIds[i] === originalIngredient.id
+      })
+      const addedAmounts = matches.reduce((mergedIngredient, duplicate) => {
+        counter += duplicate.amount
+        mergedIngredient = duplicate
+        mergedIngredient.amount = counter
+        return mergedIngredient
+      }, {})
+      finalArray.push(addedAmounts)
+    }
+    return finalArray
   }
 }
 

--- a/src/classes/Recipe.js
+++ b/src/classes/Recipe.js
@@ -1,4 +1,3 @@
-const { testIngredients, recipeData, ingredientsData } = require("../data/testData")
 const Ingredient = require("./Ingredient")
 
 class Recipe {
@@ -26,10 +25,10 @@ class Recipe {
     return this.mergeIngredients(a)
   }
 
-  mergeIngredients(ingredientsData) {
+  mergeIngredients(ingredientsDataWithDuplicates) {
     let counter = 0
     let finalArray = []
-    const listUniqueIds = ingredientsData.reduce((acc, curr) => {
+    const listUniqueIds = ingredientsDataWithDuplicates.reduce((acc, curr) => {
       if (!acc.includes(curr.id)) {
         acc.push(curr.id)
       }
@@ -37,7 +36,7 @@ class Recipe {
     }, [])
     for (var i = 0; i < listUniqueIds.length; i++) {
       counter = 0
-      const matches = ingredientsData.filter((originalIngredient) => {
+      const matches = ingredientsDataWithDuplicates.filter((originalIngredient) => {
         return listUniqueIds[i] === originalIngredient.id
       })
       const addedAmounts = matches.reduce((mergedIngredient, duplicate) => {

--- a/src/classes/Recipe.js
+++ b/src/classes/Recipe.js
@@ -23,9 +23,9 @@ class Recipe {
       let targetDatasetObject = ingredientsData.find(datasetObj => recipeObject.id === datasetObj.id)
       return new Ingredient(targetDatasetObject, recipeObject)
     })
-
     return this.mergeIngredients(a)
   }
+
   mergeIngredients(ingredientsData) {
     let counter = 0
     let finalArray = []


### PR DESCRIPTION
### Summary: 
This PR adds the `mergeIngredients()` function in `Recipe.js` that looks at recipe ingredients and merges any duplicates. 

### How to test:
Click into multiple recipe tiles and check to see there are no duplicates. See example in screenshots below.

### Before:
![image](https://user-images.githubusercontent.com/110144802/200223019-f9dfecc7-bd36-48b6-93b7-a18ed62bce3a.png)

### After: 
<img width="1048" alt="image" src="https://user-images.githubusercontent.com/110144802/200223060-4cdad871-b288-435a-b1bb-91d576e35232.png">
