### PR TITLE
PATCH: pantry ingredients not updating/422 when POSTing

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -14,7 +14,6 @@ function postData(body, url) {
       'Content-Type': 'application/json'
     }
   })
-  .then(() => getData(url))
 }
 
 export { getData, postData } 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -225,17 +225,12 @@ modalCookButton.addEventListener("click", (e) => {
 })
 
 table.addEventListener('click', (event) => {
-  if (event.target.id === 'table-button-add') {
+  if (event.target.id !== 'table-button-add') { return }
     let inputValue = Number(event.target.parentNode.querySelector('select').value)
     let id = Number(event.target.classList.value)
     let restructuredPantryObj = structurePost(user.id, id, inputValue)
     postData(restructuredPantryObj, 'http://localhost:3001/api/v1/users')
-      .then(data => {
-        usersData = data
-        user.pantry = user.getAllPantryIngredients(updateUser().pantry, recipeRepository.allIngredients)
-        displayPantryView()
-      })
-  } else { return }
+      .then(() => fetchUsers())
 })
 
 // ---------------------------DOM UPDATING---------------------------
@@ -493,12 +488,15 @@ function cookRecipe(recipe) {
     return structurePost(user.id, ingredient.id, amount)
   })
   for (let i = 0; i < bodies.length; i++) {
-    fetch('http://localhost:3001/api/v1/users', {method: 'POST', body: JSON.stringify(bodies[i]),
-      headers: {'Content-Type': 'application/json'}})
-    .then(response => response.json())
+    postData(bodies[i], 'http://localhost:3001/api/v1/users')
+    .then(() => {
+      if (i === bodies.length - 1) {
+        MicroModal.close("modal-1")
+        fetchUsers()
+      }
+    })
     .catch(err => console.log(err))
   }
-  fetchUsers()
 }
 
 function fetchUsers() {
@@ -507,7 +505,6 @@ function fetchUsers() {
   .then(data => usersData = data)
   .then(() => {
     user.pantry = user.getAllPantryIngredients(updateUser().pantry, recipeRepository.allIngredients)
-    MicroModal.close("modal-1")
     displayPantryView()
     displayMyRecipes()
   })


### PR DESCRIPTION
## This branch is a patch for the following bug:

### Description:

After adding items to the pantry, DOM-updated pantry items reflected the state of the pantry "one step behind". For example, adding 100 of an ingredient twice in a row would only display 100 total units of an item. In addition, after adding more than two items to the pantry, the following error would be thrown in the console:

![image](https://user-images.githubusercontent.com/108169988/200221672-a9d03e2e-2730-4e81-a9e7-fa90f3a37aa2.png)

### Possible Reasons for Bug:

- It's possible that the placement of the invocation of `fetchUsers()` from within `cookRecipe()` was causing the 422. `fetchUsers()` was being invoked after the `for` loop terminated, but possibly before the Promise of the final POST in the `for` loop had resolved.
- It may have also been related to the invocation of `getData()` from within the `.then` block of `postData()`. 

### The following changes were made to both DRY up scripts.js/api-calls.js and fix the bug:

- `fetchUsers()` is now invoked from within a `.then` block, in the `for` loop of `cookRecipe()` to ensure that the final Promise of the `for` loop has resolved before fetching for updated data.
- `postData()` is now used for both `cookRecipe()` and in the pantry event handler.
- `MicroModal.close()` was moved out of `fetchUsers()` and into `cookRecipe()` in order to make `fetchUsers()` modular. The modal only needs to be closed when the user "cooks" a recipe while viewing a recipe modal.

### Testing:

The reviewer of this PR should clone this branch down and check every piece of POST-related functionality, since it has been fundamentally altered. 
